### PR TITLE
Fixed Maintenance popups getting out of screen on the start and on the end of the grid rows

### DIFF
--- a/src/content/listing.js
+++ b/src/content/listing.js
@@ -1,10 +1,13 @@
 import {createMaintenancePopup} from "$lib/components/MaintenancePopup.js";
 import {createMediaBoxTools} from "$lib/components/MediaBoxTools.js";
-import {initializeMediaBox} from "$lib/components/MediaBoxWrapper.js";
+import {calculateMediaBoxesPositions, initializeMediaBox} from "$lib/components/MediaBoxWrapper.js";
 import {createMaintenanceStatusIcon} from "$lib/components/MaintenanceStatusIcon.js";
 import {createImageShowFullscreenButton} from "$lib/components/ImageShowFullscreenButton.js";
 
-document.querySelectorAll('.media-box').forEach(mediaBoxElement => {
+/** @type {NodeListOf<HTMLElement>} */
+const mediaBoxes = document.querySelectorAll('.media-box');
+
+mediaBoxes.forEach(mediaBoxElement => {
   initializeMediaBox(mediaBoxElement, [
     createMediaBoxTools(
       createMaintenancePopup(),
@@ -18,3 +21,5 @@ document.querySelectorAll('.media-box').forEach(mediaBoxElement => {
     window.dispatchEvent(new CustomEvent('resize'));
   })
 });
+
+calculateMediaBoxesPositions(mediaBoxes);

--- a/src/lib/components/MediaBoxWrapper.js
+++ b/src/lib/components/MediaBoxWrapper.js
@@ -79,6 +79,29 @@ export function initializeMediaBox(mediaBoxContainer, childComponentElements) {
 }
 
 /**
+ * @param {NodeListOf<HTMLElement>} mediaBoxesList
+ */
+export function calculateMediaBoxesPositions(mediaBoxesList) {
+  window.addEventListener('resize', () => {
+    /** @type {HTMLElement|null} */
+    let lastMediaBox = null,
+      /** @type {number|null} */
+      lastMediaBoxPosition = null;
+
+    for (let mediaBoxElement of mediaBoxesList) {
+      const yPosition = mediaBoxElement.getBoundingClientRect().y;
+      const isOnTheSameLine = yPosition === lastMediaBoxPosition;
+
+      mediaBoxElement.classList.toggle('media-box--first', !isOnTheSameLine);
+      lastMediaBox?.classList.toggle('media-box--last', !isOnTheSameLine);
+
+      lastMediaBox = mediaBoxElement;
+      lastMediaBoxPosition = yPosition;
+    }
+  })
+}
+
+/**
  * @typedef {Object} ImageURIs
  * @property {string} full
  * @property {string} large

--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -95,6 +95,51 @@
     display: none;
   }
 
+  &.media-box--first:not(.media-box--last) {
+    .media-box-tools:before {
+      left: -1px;
+    }
+
+    .media-box-tools:after {
+      right: -75%;
+    }
+
+    .maintenance-popup {
+      left: -1px;
+      right: -75%;
+    }
+  }
+
+  &.media-box--last:not(.media-box--first) {
+    .media-box-tools:before {
+      left: -75%;
+    }
+
+    .media-box-tools:after {
+      right: -1px;
+    }
+
+    .maintenance-popup {
+      left: -75%;
+      right: -1px;
+    }
+  }
+
+  &.media-box--last.media-box--first {
+    .media-box-tools:before {
+      left: -1px;
+    }
+
+    .media-box-tools:after {
+      right: -1px;
+    }
+
+    .maintenance-popup {
+      left: -1px;
+      right: -1px;
+    }
+  }
+
   &:hover {
     .media-box-tools.has-active-profile {
       &:before, &:after {


### PR DESCRIPTION
This PR fixes the issue shown on these screenshots:

![Image near the left corner of the window, popup getting out of the screen](https://github.com/koloml/furbooru-tagging-assistant/assets/15185230/36cfa930-6622-47af-aed3-3d2d3c6e9aef)

![Image near the right corner of the window, popup getting out of screen](https://github.com/koloml/furbooru-tagging-assistant/assets/15185230/c7b276a3-5884-44f0-ba20-e0bc88aba476)

Now popups will be moved back to fit on the screen:

![Image near the left corner of the window, popup placed properly and not getting out of screen](https://github.com/koloml/furbooru-tagging-assistant/assets/15185230/f447643d-5e89-4b35-8663-9e86b3bb2883)

![Image near the right corner of the window, popup placed properly and not getting out of screen](https://github.com/koloml/furbooru-tagging-assistant/assets/15185230/e7e3e4a7-bacd-46ce-8312-a6b8fcaaff6d)
