### PR TITLE
Re-import base input styling removed with Tags Editor styling back to main popup stylesheet

### DIFF
--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -30,5 +30,6 @@ a {
   }
 }
 
+@import "injectable/input";
 @import "injectable/tag";
 @import "injectable/icons";


### PR DESCRIPTION
Forgot to move import out of tags editor into the main popup stylesheet.