### PR TITLE
Prompt the browser confirmation popup when attempting to change or close the tab before all submissions are processed

### DIFF
--- a/src/lib/components/MaintenanceStatusIcon.js
+++ b/src/lib/components/MaintenanceStatusIcon.js
@@ -38,7 +38,11 @@ export class MaintenanceStatusIcon extends BaseComponent {
         break;
 
       case "complete":
-        this.container.innerText = '✅'
+        this.container.innerText = '✅';
+        break;
+
+      case "failed":
+        this.container.innerText = '⚠️';
         break;
 
       default:


### PR DESCRIPTION
It will be better to make this behavior configurable in the future, since it could be quite annoying for some people.