### PR TITLE
Fixed missing extension ID required for publishing to Firefox extensions store

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Furbooru Tagging Assistant",
     "description": "Experimental extension with a set of tools to make the tagging faster and easier. Made specifically for Furbooru.",
-    "version": "0.2.0",
+    "version": "0.2.0.1",
     "browser_specific_settings": {
         "gecko": {
             "id": "furbooru-tagging-assistant@thecore.city"

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,11 @@
     "name": "Furbooru Tagging Assistant",
     "description": "Experimental extension with a set of tools to make the tagging faster and easier. Made specifically for Furbooru.",
     "version": "0.2.0",
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "furbooru-tagging-assistant@thecore.city"
+        }
+    },
     "icons": {
         "16": "icon16.png",
         "48": "icon48.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "furbooru-tagging-assistant",
-    "version": "0.2.0",
+    "version": "0.2.0.1",
     "private": true,
     "scripts": {
         "build": "npm run build:popup && npm run build:extension",


### PR DESCRIPTION
Missed the requirement, this fix is just adding the proper ID for the extension. This PR is marked as release v0.2.0.1.