### PR TITLE
Sort listing of profiles & tags in profile view alphabetically

### DIFF
--- a/src/components/maintenance/ProfileView.svelte
+++ b/src/components/maintenance/ProfileView.svelte
@@ -1,6 +1,8 @@
 <script>
     /** @type {import('$lib/extension/entities/MaintenanceProfile.js').default} */
     export let profile;
+
+    const sortedTagsList = profile.settings.tags.sort((a, b) => a.localeCompare(b));
 </script>
 
 <div class="block">
@@ -10,7 +12,7 @@
 <div class="block">
     <strong>Tags:</strong>
     <div class="tags-list">
-        {#each profile.settings.tags as tagName}
+        {#each sortedTagsList as tagName}
             <span class="tag">{tagName}</span>
         {/each}
     </div>

--- a/src/routes/settings/maintenance/+page.svelte
+++ b/src/routes/settings/maintenance/+page.svelte
@@ -7,7 +7,7 @@
     /** @type {import('$lib/extension/entities/MaintenanceProfile.js').default[]} */
     let profiles = [];
 
-    $: profiles = $maintenanceProfilesStore.sort((a, b) => b.settings.name.localeCompare(a.settings.name));
+    $: profiles = $maintenanceProfilesStore.sort((a, b) => a.settings.name.localeCompare(b.settings.name));
 
     function resetActiveProfile() {
         $activeProfileStore = null;

--- a/src/routes/settings/maintenance/[id]/edit/+page.svelte
+++ b/src/routes/settings/maintenance/[id]/edit/+page.svelte
@@ -28,7 +28,7 @@
         if (maybeExistingProfile) {
             targetProfile = maybeExistingProfile;
             profileName = targetProfile.settings.name;
-            tagsList = [...targetProfile.settings.tags];
+            tagsList = [...targetProfile.settings.tags].sort((a, b) => a.localeCompare(b));
         } else {
             goto('/settings/maintenance');
         }


### PR DESCRIPTION
Sorting of tags was all over the place and the listing was sorted incorrectly (in inversed order). Now they're sorted from A-Z.

Tags are sorted only in editor and in viewer, saved tags could still be saved without proper sorting.