### PR TITLE
Show the tagging profiles popup in galleries view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,8 @@
                 "*://*.furbooru.org/",
                 "*://*.furbooru.org/images?*",
                 "*://*.furbooru.org/search?*",
-                "*://*.furbooru.org/tags/*"
+                "*://*.furbooru.org/tags/*",
+                "*://*.furbooru.org/galleries/*"
             ],
             "js": [
                 "src/content/listing.js"


### PR DESCRIPTION
Galleries are displayed in the separate path not covered previously by the manifest. Feature seems to be working fine with the reordering logic, but might require some workaround to not mess with anything.