### PR TITLE
Tag Editor: Automatically apply category colors to the tags in the tag editor

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,14 @@
             "js": [
                 "src/content/tags.js"
             ]
+        },
+        {
+            "matches": [
+                "*://*.furbooru.org/images/*"
+            ],
+            "js": [
+                "src/content/tags-editor.js"
+            ]
         }
     ],
     "action": {

--- a/src/content/tags-editor.js
+++ b/src/content/tags-editor.js
@@ -1,7 +1,3 @@
-import {initializeTagForm} from "$lib/components/TagsForm.js";
+import {TagsForm} from "$lib/components/TagsForm.js";
 
-const tagsEditorContainer = document.querySelector('#tags-form');
-
-if (tagsEditorContainer) {
-  initializeTagForm(tagsEditorContainer);
-}
+TagsForm.watchForEditors();

--- a/src/content/tags-editor.js
+++ b/src/content/tags-editor.js
@@ -1,0 +1,7 @@
+import {initializeTagForm} from "$lib/components/TagsForm.js";
+
+const tagsEditorContainer = document.querySelector('#tags-form');
+
+if (tagsEditorContainer) {
+  initializeTagForm(tagsEditorContainer);
+}

--- a/src/lib/components/TagsForm.js
+++ b/src/lib/components/TagsForm.js
@@ -1,30 +1,11 @@
 import {BaseComponent} from "$lib/components/base/BaseComponent.js";
+import {getComponent} from "$lib/components/base/ComponentUtils.js";
 
-class TagsForm extends BaseComponent {
-  /**
-   * Button to edit tags for the image.
-   * @type {HTMLElement|null}
-   */
-  #editTagButton;
-
-  build() {
-    this.#editTagButton = document.querySelector('#edit-tags');
-  }
-
-  init() {
-    if (this.#editTagButton) {
-      this.#editTagButton.addEventListener('click', this.#onEditClicked.bind(this));
-    }
-  }
-
-  #onEditClicked() {
-    this.#refreshTagColors();
-  }
-
+export class TagsForm extends BaseComponent {
   /**
    * Collect all the tag categories available on the page and color the tags in the editor according to them.
    */
-  #refreshTagColors() {
+  refreshTagColors() {
     const tagCategories = this.#gatherTagCategories();
     const editableTags = this.container.querySelectorAll('.tag');
 
@@ -63,8 +44,38 @@ class TagsForm extends BaseComponent {
 
     return tagCategories;
   }
-}
 
-export function initializeTagForm(container) {
-  new TagsForm(container).initialize();
+  static watchForEditors() {
+    document.body.addEventListener('click', event => {
+      const targetElement = event.target;
+
+      if (!(targetElement instanceof HTMLElement)) {
+        return;
+      }
+
+      const tagEditorWrapper = targetElement.closest('#image_tags_and_source');
+
+      if (!tagEditorWrapper) {
+        return;
+      }
+
+      const refreshTrigger = targetElement.closest('.js-taginput-show, #edit-tags')
+
+      if (!refreshTrigger) {
+        return;
+      }
+
+      const tagFormElement = tagEditorWrapper.querySelector('#tags-form');
+
+      /** @type {TagsForm|null} */
+      let tagEditor = getComponent(tagFormElement);
+
+      if (!tagEditor || (!tagEditor instanceof TagsForm)) {
+        tagEditor = new TagsForm(tagFormElement);
+        tagEditor.initialize();
+      }
+
+      tagEditor.refreshTagColors();
+    });
+  }
 }

--- a/src/lib/components/TagsForm.js
+++ b/src/lib/components/TagsForm.js
@@ -1,0 +1,70 @@
+import {BaseComponent} from "$lib/components/base/BaseComponent.js";
+
+class TagsForm extends BaseComponent {
+  /**
+   * Button to edit tags for the image.
+   * @type {HTMLElement|null}
+   */
+  #editTagButton;
+
+  build() {
+    this.#editTagButton = document.querySelector('#edit-tags');
+  }
+
+  init() {
+    if (this.#editTagButton) {
+      this.#editTagButton.addEventListener('click', this.#onEditClicked.bind(this));
+    }
+  }
+
+  #onEditClicked() {
+    this.#refreshTagColors();
+  }
+
+  /**
+   * Collect all the tag categories available on the page and color the tags in the editor according to them.
+   */
+  #refreshTagColors() {
+    const tagCategories = this.#gatherTagCategories();
+    const editableTags = this.container.querySelectorAll('.tag');
+
+    for (let tagElement of editableTags) {
+      // Tag name is stored in the "remove" link and not in the tag itself.
+      const removeLink = tagElement.querySelector('a');
+
+      if (!removeLink) {
+        continue;
+      }
+
+      const tagName = removeLink.dataset.tagName;
+
+      if (!tagCategories.has(tagName)) {
+        continue;
+      }
+
+      const categoryName = tagCategories.get(tagName);
+
+      tagElement.dataset.tagCategory = categoryName;
+      tagElement.setAttribute('data-tag-category', categoryName);
+    }
+  }
+
+  /**
+   * Collect list of categories from the tags on the page.
+   * @return {Map<string, string>}
+   */
+  #gatherTagCategories() {
+    /** @type {Map<string, string>} */
+    const tagCategories = new Map();
+
+    for (let tagElement of document.querySelectorAll('.tag[data-tag-name][data-tag-category]')) {
+      tagCategories.set(tagElement.dataset.tagName, tagElement.dataset.tagCategory);
+    }
+
+    return tagCategories;
+  }
+}
+
+export function initializeTagForm(container) {
+  new TagsForm(container).initialize();
+}


### PR DESCRIPTION
Self-explanatory, color will be directly applied from the tags displayed on the image page.

![image](https://github.com/user-attachments/assets/b67cc4ae-6d16-4029-bbb1-e351c1dc5d0b)

![image](https://github.com/user-attachments/assets/42e8e2aa-0615-44c0-a940-0000b103639e)

This means, new tags will not receive the colors when added, only after the tags were saved and editor was reopened again.