### PR TITLE
Fixed option to add tag to profile not showing up on the index tags page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,7 @@
                 "*://*.furbooru.org/images/*/tag_changes",
                 "*://*.furbooru.org/images/*/tag_changes?*",
                 "*://*.furbooru.org/search?*",
+                "*://*.furbooru.org/tags",
                 "*://*.furbooru.org/tags?*",
                 "*://*.furbooru.org/tags/*",
                 "*://*.furbooru.org/profiles/*/tag_changes",


### PR DESCRIPTION
Issue was caused by my not including the needed pattern into the manifest. Now option will show up properly.