### PR TITLE
Display currently active profile on the main view of the popup

### DIFF
--- a/src/components/ui/menu/MenuCheckboxItem.svelte
+++ b/src/components/ui/menu/MenuCheckboxItem.svelte
@@ -1,0 +1,36 @@
+<script>
+    import MenuLink from "$components/ui/menu/MenuItem.svelte";
+
+    /**
+     * @type {boolean}
+     */
+    export let checked;
+
+    /**
+     * @type {string|undefined}
+     */
+    export let name = undefined;
+
+    /**
+     * @type {string|undefined}
+     */
+    export let value = undefined;
+
+    /**
+     * @type {string|null}
+     */
+    export let href = null;
+</script>
+
+<MenuLink {href}>
+    <input type="checkbox" {name} {value} {checked} on:input on:click|stopPropagation>
+    <slot></slot>
+</MenuLink>
+
+<style lang="scss">
+    :global(.menu-item) input {
+        width: 16px;
+        height: 16px;
+        margin-right: 6px;
+    }
+</style>

--- a/src/components/ui/menu/MenuCheckboxItem.svelte
+++ b/src/components/ui/menu/MenuCheckboxItem.svelte
@@ -32,5 +32,6 @@
         width: 16px;
         height: 16px;
         margin-right: 6px;
+        flex-shrink: 0;
     }
 </style>

--- a/src/components/ui/menu/MenuRadioItem.svelte
+++ b/src/components/ui/menu/MenuRadioItem.svelte
@@ -32,5 +32,6 @@
         width: 16px;
         height: 16px;
         margin-right: 6px;
+        flex-shrink: 0;
     }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,26 @@
 <script>
     import Menu from "$components/ui/menu/Menu.svelte";
     import MenuItem from "$components/ui/menu/MenuItem.svelte";
+    import { activeProfileStore, maintenanceProfilesStore } from "$stores/maintenance-profiles-store.js";
+    import MenuCheckboxItem from "$components/ui/menu/MenuCheckboxItem.svelte";
+
+    /** @type {import('$lib/extension/entities/MaintenanceProfile.js').default|undefined} */
+    let activeProfile;
+
+    $: activeProfile = $maintenanceProfilesStore.find(profile => profile.id === $activeProfileStore);
+
+    function turnOffActiveProfile() {
+        $activeProfileStore = null;
+    }
 </script>
 
 <Menu>
+    {#if activeProfile}
+        <MenuCheckboxItem checked on:input={turnOffActiveProfile} href="/features/maintenance/{activeProfile.id}">
+            Active Profile: {activeProfile.settings.name}
+        </MenuCheckboxItem>
+        <hr>
+    {/if}
     <MenuItem href="/features/maintenance">Tagging Profiles</MenuItem>
     <hr>
     <MenuItem href="/preferences">Preferences</MenuItem>


### PR DESCRIPTION
Introduces quick access to the currently active profile right from the index view saving 1-2 more clicks to disable or change the active profile. Profile link shows up on top of the list of features:

![image](https://github.com/user-attachments/assets/a7b1f330-c197-4db4-9932-6134d4ca7c25)

Checking off the checkbox will turn off the profile. Clicking on the link will lead to the profile view.