### PR TITLE
Fixed profile not being refreshed after initial page load

### DIFF
--- a/src/lib/components/MaintenancePopup.js
+++ b/src/lib/components/MaintenancePopup.js
@@ -286,7 +286,13 @@ export class MaintenancePopup extends BaseComponent {
 
     this.#maintenanceSettings
       .resolveActiveProfileAsObject()
-      .then(callback);
+      .then(profileOrNull => {
+        if (profileOrNull) {
+          lastActiveProfileId = profileOrNull.id;
+        }
+
+        callback(profileOrNull);
+      });
 
     return () => {
       unsubscribeFromProfilesChanges();


### PR DESCRIPTION
Active profile ID was not loaded properly on the initial page load, causing popup to not update the list of tags until user selected different profile without reloading the page.

- Fixes #33 