### PR TITLE
Fixed preferences not being sycnhronized back from browser storage to popup view

### DIFF
--- a/src/stores/misc-preferences.js
+++ b/src/stores/misc-preferences.js
@@ -10,5 +10,9 @@ Promise.allSettled([
 ]).then(() => {
   fullScreenViewerEnabled.subscribe(value => {
     void miscSettings.setFullscreenViewerEnabled(value);
-  })
+  });
+
+  miscSettings.subscribe(settings => {
+    fullScreenViewerEnabled.set(settings.fullscreenViewer);
+  });
 });

--- a/src/stores/search-preferences.js
+++ b/src/stores/search-preferences.js
@@ -21,4 +21,9 @@ Promise.allSettled([
   searchPropertiesSuggestionsPosition.subscribe(value => {
     void searchSettings.setPropertiesSuggestionsPosition(value);
   });
+
+  searchSettings.subscribe(settings => {
+    searchPropertiesSuggestionsEnabled.set(settings.suggestProperties);
+    searchPropertiesSuggestionsPosition.set(settings.suggestPropertiesPosition);
+  });
 })


### PR DESCRIPTION
Looks like I forgot to synchronize changes made outside of current popup back to the stores. While these are primitive values, I don't need to check if they're the same or not, so there will be no infinite loops here.

- Fixes #56