### PR TITLE
Fullscreen Viewer: Added image/video quality setting and more explicit "close" icon

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -25,6 +25,13 @@ declare global {
     interface EntityNamesMap {
       profiles: MaintenanceProfile;
     }
+
+    interface ImageURIs {
+      full: string;
+      large: string;
+      medium: string;
+      small: string;
+    }
   }
 }
 

--- a/src/lib/components/FullscreenViewer.js
+++ b/src/lib/components/FullscreenViewer.js
@@ -8,6 +8,7 @@ export class FullscreenViewer extends BaseComponent {
   #imageElement = document.createElement('img');
   #spinnerElement = document.createElement('i');
   #sizeSelectorElement = document.createElement('select');
+  #closeButtonElement = document.createElement('i');
   /** @type {number|null} */
   #touchId = null;
   /** @type {number|null} */
@@ -29,9 +30,11 @@ export class FullscreenViewer extends BaseComponent {
     this.container.append(
       this.#spinnerElement,
       this.#sizeSelectorElement,
+      this.#closeButtonElement,
     );
 
     this.#spinnerElement.classList.add('spinner', 'fa', 'fa-circle-notch', 'fa-spin');
+    this.#closeButtonElement.classList.add('close', 'fa', 'fa-xmark');
     this.#sizeSelectorElement.classList.add('size-selector', 'input');
 
     for (const [sizeKey, sizeName] of Object.entries(FullscreenViewer.#previewSizes)) {

--- a/src/lib/components/FullscreenViewer.js
+++ b/src/lib/components/FullscreenViewer.js
@@ -17,6 +17,8 @@ export class FullscreenViewer extends BaseComponent {
   /** @type {boolean|null} */
   #isClosingSwipeStarted = null;
   #isSizeFetched = false;
+  /** @type {App.ImageURIs|null} */
+  #currentURIs = null;
 
   /**
    * @protected
@@ -210,6 +212,10 @@ export class FullscreenViewer extends BaseComponent {
     this.#sizeSelectorElement.addEventListener('input', () => {
       const targetSize = this.#sizeSelectorElement.value;
 
+      if (this.#currentURIs) {
+        void this.show(this.#currentURIs);
+      }
+
       if (!targetSize || targetSize === lastActiveSize || !(targetSize in FullscreenViewer.#previewSizes)) {
         return;
       }
@@ -220,6 +226,8 @@ export class FullscreenViewer extends BaseComponent {
   }
 
   #close() {
+    this.#currentURIs = null;
+
     this.container.classList.remove(FullscreenViewer.#shownState);
     document.body.style.overflow = null;
 
@@ -260,6 +268,8 @@ export class FullscreenViewer extends BaseComponent {
    * @param {App.ImageURIs} imageUris
    */
   async show(imageUris) {
+    this.#currentURIs = imageUris;
+
     const url = await this.#resolveCurrentSelectedSizeUrl(imageUris);
 
     if (!url) {

--- a/src/lib/components/FullscreenViewer.js
+++ b/src/lib/components/FullscreenViewer.js
@@ -53,6 +53,7 @@ export class FullscreenViewer extends BaseComponent {
 
     this.#videoElement.addEventListener('loadeddata', this.#onLoaded.bind(this));
     this.#imageElement.addEventListener('load', this.#onLoaded.bind(this));
+    this.#sizeSelectorElement.addEventListener('click', event => event.stopPropagation());
 
     FullscreenViewer.#miscSettings
       .resolveFullscreenViewerPreviewSize()

--- a/src/lib/components/ImageShowFullscreenButton.js
+++ b/src/lib/components/ImageShowFullscreenButton.js
@@ -33,7 +33,7 @@ export class ImageShowFullscreenButton extends BaseComponent {
         })
         .then(() => {
           ImageShowFullscreenButton.#miscSettings.subscribe(settings => {
-            this.#isFullscreenButtonEnabled = settings.fullscreenViewer;
+            this.#isFullscreenButtonEnabled = settings.fullscreenViewer ?? true;
             this.#updateFullscreenButtonVisibility();
           })
         })

--- a/src/lib/components/ImageShowFullscreenButton.js
+++ b/src/lib/components/ImageShowFullscreenButton.js
@@ -47,7 +47,7 @@ export class ImageShowFullscreenButton extends BaseComponent {
   #onButtonClicked() {
     ImageShowFullscreenButton
       .#resolveViewer()
-      .show(this.#mediaBoxTools.mediaBox.imageLinks.large);
+      .show(this.#mediaBoxTools.mediaBox.imageLinks);
   }
 
   /**

--- a/src/lib/components/MediaBoxWrapper.js
+++ b/src/lib/components/MediaBoxWrapper.js
@@ -56,7 +56,7 @@ export class MediaBoxWrapper extends BaseComponent {
   }
 
   /**
-   * @return {ImageURIs}
+   * @return {App.ImageURIs}
    */
   get imageLinks() {
     return JSON.parse(this.#thumbnailContainer.dataset.uris);
@@ -100,10 +100,3 @@ export function calculateMediaBoxesPositions(mediaBoxesList) {
     }
   })
 }
-
-/**
- * @typedef {Object} ImageURIs
- * @property {string} full
- * @property {string} large
- * @property {string} small
- */

--- a/src/lib/extension/settings/MiscSettings.ts
+++ b/src/lib/extension/settings/MiscSettings.ts
@@ -1,7 +1,10 @@
 import CacheableSettings from "$lib/extension/base/CacheableSettings.ts";
 
+export type FullscreenViewerSize = 'small' | 'medium' | 'large' | 'full';
+
 interface MiscSettingsFields {
   fullscreenViewer: boolean;
+  fullscreenViewerSize: FullscreenViewerSize;
 }
 
 export default class MiscSettings extends CacheableSettings<MiscSettingsFields> {
@@ -13,7 +16,15 @@ export default class MiscSettings extends CacheableSettings<MiscSettingsFields> 
     return this._resolveSetting("fullscreenViewer", true);
   }
 
+  async resolveFullscreenViewerPreviewSize() {
+    return this._resolveSetting('fullscreenViewerSize', 'large');
+  }
+
   async setFullscreenViewerEnabled(isEnabled: boolean) {
     return this._writeSetting("fullscreenViewer", isEnabled);
+  }
+
+  async setFullscreenViewerPreviewSize(size: FullscreenViewerSize | string) {
+    return this._writeSetting('fullscreenViewerSize', size as FullscreenViewerSize);
   }
 }

--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -203,6 +203,7 @@
     position: absolute;
     top: 5px;
     left: 5px;
+    z-index: 1;
   }
 
   &.shown {

--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -206,6 +206,23 @@
     z-index: 1;
   }
 
+  .close {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    z-index: 1;
+    padding: 5px;
+    background-color: colors.$text;
+    color: colors.$background;
+    font-size: 20px;
+    line-height: 20px;
+    width: 20px;
+    height: 20px;
+    text-align: center;
+    display: block;
+    cursor: pointer;
+  }
+
   &.shown {
     opacity: var(--opacity, 1);
     pointer-events: initial;

--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -199,6 +199,12 @@
     transition: opacity .25s ease;
   }
 
+  .size-selector {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+  }
+
   &.shown {
     opacity: var(--opacity, 1);
     pointer-events: initial;


### PR DESCRIPTION
Now user can control what kind of size of image they want to load in this viewer using this new selector in the top-left corner. For now, only "Full", "Large", "Medium" and "Small" are included. There are a few more sizes available on the booru, but they seem a little bit unusable.

![image](https://github.com/user-attachments/assets/f00ff9f0-03be-465b-9554-15469acd07a0)

This change also includes this "close" icon in the top-right corner, especially useful in Firefox where clicks on the video are not closing the viewer.

![image](https://github.com/user-attachments/assets/43b9db4b-f129-4f99-b78f-22356409f4c8)
