### PR TITLE
Fixed fallback redirect when visiting profile with ID "new"

### DIFF
--- a/src/routes/features/maintenance/[id]/+page.svelte
+++ b/src/routes/features/maintenance/[id]/+page.svelte
@@ -12,7 +12,7 @@
     let isActiveProfile = false;
 
     if (profileId === 'new') {
-        goto('/maintenance/profiles/new/edit');
+        goto('/features/maintenance/new/edit');
     }
 
     $: {


### PR DESCRIPTION
Very minor fix of the missed redirect, which would never occur normally.