### PR TITLE
Fixed tag in popups having broken appearance after themes updates for Philomena, updated how colors applied to tags

### DIFF
--- a/.vite/lib/content-scripts.js
+++ b/.vite/lib/content-scripts.js
@@ -112,6 +112,9 @@ export async function buildStyle(buildOptions) {
         }
       },
       emptyOutDir: false,
+    },
+    resolve: {
+      alias: makeAliases(buildOptions.rootDir)
     }
   });
 

--- a/src/styles/booru-colors.scss
+++ b/src/styles/booru-colors.scss
@@ -1,0 +1,4 @@
+// These variables are defined dynamically based on the category of the tag
+$resolved-tag-background: var(--tag-background);
+$resolved-tag-border: var(--tag-border);
+$resolved-tag-color: var(--tag-color);

--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -62,7 +62,7 @@
 
     .tag {
       cursor: pointer;
-      padding: 0 6px;
+      padding: 5px;
       user-select: none;
 
       &:hover {

--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -1,4 +1,5 @@
-@use '../colors';
+@use '$styles/colors';
+@use '$styles/booru-colors';
 
 // This will fix wierd misplacing of the modified media boxes in the listing.
 .js-resizable-media-container {
@@ -66,13 +67,8 @@
       user-select: none;
 
       &:hover {
-        background: colors.$tag-text;
-        color: colors.$tag-background;
-      }
-
-      &[data-tag-category=error]:hover {
-        background: colors.$tag-error-text;
-        color: colors.$tag-error-background;
+        background: booru-colors.$resolved-tag-color;
+        color: booru-colors.$resolved-tag-background;
       }
 
       &.is-missing:not(.is-added),


### PR DESCRIPTION
Recently, styling updates were pushed to the Furbooru from the main Philomena repo. This styling update broke the tags in the popups: they lost their vertical paddings. This PR fixes that and, additionally, switches the hardcoded color overrides on the hover to the site variables.