### PR TITLE
Fullscreen Viewer: Fixed size selector not having backgronud color making it difficult to read with certain images

### DIFF
--- a/src/styles/content/listing.scss
+++ b/src/styles/content/listing.scss
@@ -203,6 +203,7 @@
     top: 5px;
     left: 5px;
     z-index: 1;
+    background-color: booru-vars.$background-color;
   }
 
   .close {


### PR DESCRIPTION
This issue fixes #79. Selector now uses default background color from currently active theme.