### PR TITLE
StorageHelper: Fixed helper treating falsy values as unset values

### DIFF
--- a/src/lib/browser/StorageHelper.ts
+++ b/src/lib/browser/StorageHelper.ts
@@ -22,7 +22,7 @@ export default class StorageHelper {
    * @return The JSON object or the default value if the entry does not exist.
    */
   async read<Type = any, DefaultType = any>(key: string, defaultValue: DefaultType | null = null): Promise<Type | DefaultType> {
-    return (await this.#storageArea.get(key))?.[key] || defaultValue;
+    return (await this.#storageArea.get(key))?.[key] ?? defaultValue;
   }
 
   /**


### PR DESCRIPTION
This issue existed and never got caught since `StorageHelper` is only used to store and read objects. Issue was caught during setup of the Vitest for testsing in #96.