### PR TITLE
Fixed tests running twice on release PRs

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - master
-            - 'release/**'
     pull_request:
         branches:
             - master


### PR DESCRIPTION
Tests mistakenly running twice due to both `push` and `pull_request` rules applying. Tests should only run for release PR and not on the actual pushes.