### PR TITLE
Tag Groups: Fixed incorrect path on the "Back" link for group editor view

### DIFF
--- a/src/routes/features/groups/[id]/edit/+page.svelte
+++ b/src/routes/features/groups/[id]/edit/+page.svelte
@@ -75,7 +75,7 @@
 </script>
 
 <Menu>
-  <MenuItem href="/features/groups/{groupId !== 'new' ? '' : groupId}" icon="arrow-left">Back</MenuItem>
+  <MenuItem href="/features/groups/{groupId === 'new' ? '' : groupId}" icon="arrow-left">Back</MenuItem>
   <hr>
 </Menu>
 <FormContainer>


### PR DESCRIPTION
Incorrect condition was creating invalid path to go back to, causing the back link to lead to the same page.