### PR TITLE
Fixed tag group colors & grouping not applying in Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,14 @@
         },
         {
             "matches": [
+                "*://*.furbooru.org/images/*"
+            ],
+            "js": [
+                "src/content/tags-editor.ts"
+            ]
+        },
+        {
+            "matches": [
                 "*://*.furbooru.org/images?*",
                 "*://*.furbooru.org/images/*",
                 "*://*.furbooru.org/images/*/tag_changes",
@@ -60,14 +68,6 @@
             ],
             "js": [
                 "src/content/tags.ts"
-            ]
-        },
-        {
-            "matches": [
-                "*://*.furbooru.org/images/*"
-            ],
-            "js": [
-                "src/content/tags-editor.ts"
             ]
         }
     ],


### PR DESCRIPTION
For some reason, this feature stopped working properly after 0.4.3 in Firefox specifically. Since I'm only using Chrome during development, I didn't caught the issue before the release.

I think, I'd need to make sure that it doesn't matter which script is loading first and which is not, but for now, I'll just reorder them.