### PR TITLE
Fixed last media box on the page showing its popup outside of the viewport

### DIFF
--- a/src/lib/components/MediaBoxWrapper.ts
+++ b/src/lib/components/MediaBoxWrapper.ts
@@ -3,6 +3,7 @@ import { getComponent } from "$lib/components/base/component-utils";
 import { buildTagsAndAliasesMap } from "$lib/booru/tag-utils";
 import { on } from "$lib/components/events/comms";
 import { eventTagsUpdated } from "$lib/components/events/maintenance-popup-events";
+import onMessageExternal = chrome.runtime.onMessageExternal;
 
 export class MediaBoxWrapper extends BaseComponent {
   #thumbnailContainer: HTMLElement | null = null;
@@ -89,6 +90,11 @@ export function calculateMediaBoxesPositions(mediaBoxesList: NodeListOf<HTMLElem
 
       lastMediaBox = mediaBoxElement;
       lastMediaBoxPosition = yPosition;
+    }
+
+    // Last-ever media box is checked separately
+    if (lastMediaBox && !lastMediaBox.nextElementSibling) {
+      lastMediaBox.classList.add('media-box--last');
     }
   })
 }

--- a/src/lib/components/MediaBoxWrapper.ts
+++ b/src/lib/components/MediaBoxWrapper.ts
@@ -3,7 +3,6 @@ import { getComponent } from "$lib/components/base/component-utils";
 import { buildTagsAndAliasesMap } from "$lib/booru/tag-utils";
 import { on } from "$lib/components/events/comms";
 import { eventTagsUpdated } from "$lib/components/events/maintenance-popup-events";
-import onMessageExternal = chrome.runtime.onMessageExternal;
 
 export class MediaBoxWrapper extends BaseComponent {
   #thumbnailContainer: HTMLElement | null = null;


### PR DESCRIPTION
Issue was caused by the missing check for the last media box on the page.

![image](https://github.com/user-attachments/assets/1861f6b1-7e7d-4a40-8028-3e132de0f190)

Now it makes additional check for the last media box on the page and adds needed class to avoid this issue.