### PR TITLE
Tags List: Fixed re-initialization of the component after tags were submitted

### DIFF
--- a/src/lib/components/TagsListBlock.ts
+++ b/src/lib/components/TagsListBlock.ts
@@ -196,6 +196,13 @@ export function initializeAllTagsLists() {
 
 export function watchForUpdatedTagLists() {
   on(document, eventFormEditorUpdated, event => {
-    event.detail.closest('#image_tags_and_source')
+    const tagsListElement = event.detail.closest<HTMLElement>('#image_tags_and_source');
+
+    if (!tagsListElement || getComponent(tagsListElement)) {
+      return;
+    }
+
+    new TagsListBlock(tagsListElement)
+      .initialize();
   });
 }


### PR DESCRIPTION
Looks like I've missed the re-initialization for this component. Now it properly catches the new element and initializes it.