### PR TITLE
Tag Groups: Added button to the tags list component to quckly toggle the sepeartion on and off

### DIFF
--- a/src/lib/components/TagsListBlock.ts
+++ b/src/lib/components/TagsListBlock.ts
@@ -8,7 +8,12 @@ import { eventTagCustomGroupResolved } from "$lib/components/events/tag-dropdown
 import TagSettings from "$lib/extension/settings/TagSettings";
 
 export class TagsListBlock extends BaseComponent {
+  #tagsListButtonsContainer: HTMLElement | null = null;
   #tagsListContainer: HTMLElement | null = null;
+
+  #toggleGroupingButton = document.createElement('a');
+  #toggleGroupingButtonIcon = document.createElement('i');
+
   #tagSettings = new TagSettings();
 
   #shouldDisplaySeparation = false;
@@ -21,7 +26,21 @@ export class TagsListBlock extends BaseComponent {
   #isReorderingPlanned = false;
 
   protected build() {
+    this.#tagsListButtonsContainer = this.container.querySelector('.block.tagsauce .block__header__buttons');
     this.#tagsListContainer = this.container.querySelector('.tag-list');
+
+    this.#toggleGroupingButton.innerText = ' Grouping';
+    this.#toggleGroupingButton.href = 'javascript:void(0)';
+    this.#toggleGroupingButton.classList.add('button', 'button--link', 'button--inline');
+    this.#toggleGroupingButton.title = 'Toggle the global groups separation option. This will only toggle global ' +
+      'setting without changing the separation of specific groups.';
+
+    this.#toggleGroupingButtonIcon.classList.add('fas', TagsListBlock.#iconGroupingDisabled);
+    this.#toggleGroupingButton.prepend(this.#toggleGroupingButtonIcon);
+
+    if (this.#tagsListButtonsContainer) {
+      this.#tagsListButtonsContainer.append(this.#toggleGroupingButton);
+    }
   }
 
   init() {
@@ -35,6 +54,8 @@ export class TagsListBlock extends BaseComponent {
       eventTagCustomGroupResolved,
       this.#onTagDropdownCustomGroupResolved.bind(this)
     );
+
+    this.#toggleGroupingButton.addEventListener('click', this.#onToggleGroupingClicked.bind(this));
   }
 
   #onTagSeparationChange(isSeparationEnabled: boolean) {
@@ -44,6 +65,12 @@ export class TagsListBlock extends BaseComponent {
 
     this.#shouldDisplaySeparation = isSeparationEnabled;
     this.#reorderSeparatedGroups();
+    this.#updateToggleSeparationButton();
+  }
+
+  #updateToggleSeparationButton() {
+    this.#toggleGroupingButtonIcon.classList.toggle(TagsListBlock.#iconGroupingEnabled, this.#shouldDisplaySeparation);
+    this.#toggleGroupingButtonIcon.classList.toggle(TagsListBlock.#iconGroupingDisabled, !this.#shouldDisplaySeparation);
   }
 
   #onTagDropdownCustomGroupResolved(resolvedCustomGroupEvent: CustomEvent<TagGroup | null>) {
@@ -72,6 +99,11 @@ export class TagsListBlock extends BaseComponent {
 
       requestAnimationFrame(this.#reorderSeparatedGroups.bind(this));
     }
+  }
+
+  #onToggleGroupingClicked(event: Event) {
+    event.preventDefault();
+    void this.#tagSettings.setGroupSeparation(!this.#shouldDisplaySeparation);
   }
 
   #handleTagGroupChanges(tagGroup: TagGroup) {
@@ -181,6 +213,9 @@ export class TagsListBlock extends BaseComponent {
   static #orderCssVariableForGroup(groupId: string): string {
     return `--ta-order-${groupId}`;
   }
+
+  static #iconGroupingDisabled = 'fa-folder';
+  static #iconGroupingEnabled = 'fa-folder-tree';
 }
 
 export function initializeAllTagsLists() {


### PR DESCRIPTION
I've noticed that sometimes I wanted to quickly toggle the feature on and off. But doing that through the popup was quite slow and cumbersome. Now there is a button for doing that right in the tags list.

[Screencast from 2025-03-26 21-00-23.webm](https://github.com/user-attachments/assets/a6b47d23-9f6c-4f32-92d0-29c979efe10a)
