### PR TITLE
Changing the naming of custom events to be different from the usual variables

### DIFF
--- a/src/lib/components/FullscreenViewer.ts
+++ b/src/lib/components/FullscreenViewer.ts
@@ -1,7 +1,7 @@
 import { BaseComponent } from "$lib/components/base/BaseComponent";
 import MiscSettings, { type FullscreenViewerSize } from "$lib/extension/settings/MiscSettings";
 import { emit, on } from "$lib/components/events/comms";
-import { eventSizeLoaded } from "$lib/components/events/fullscreen-viewer-events";
+import { EVENT_SIZE_LOADED } from "$lib/components/events/fullscreen-viewer-events";
 
 export class FullscreenViewer extends BaseComponent {
   #videoElement: HTMLVideoElement = document.createElement('video');
@@ -173,7 +173,7 @@ export class FullscreenViewer extends BaseComponent {
     this.#sizeSelectorElement.value = size;
     this.#isSizeFetched = true;
 
-    emit(this.container, eventSizeLoaded, size);
+    emit(this.container, EVENT_SIZE_LOADED, size);
   }
 
   #watchForSizeSelectionChanges() {
@@ -224,7 +224,7 @@ export class FullscreenViewer extends BaseComponent {
       await new Promise(
         resolve => on(
           this.container,
-          eventSizeLoaded,
+          EVENT_SIZE_LOADED,
           resolve
         ),
       );

--- a/src/lib/components/MaintenancePopup.ts
+++ b/src/lib/components/MaintenancePopup.ts
@@ -6,9 +6,9 @@ import ScrapedAPI from "$lib/booru/scraped/ScrapedAPI";
 import { tagsBlacklist } from "$config/tags";
 import { emitterAt } from "$lib/components/events/comms";
 import {
-  eventActiveProfileChanged,
-  eventMaintenanceStateChanged,
-  eventTagsUpdated
+  EVENT_ACTIVE_PROFILE_CHANGED,
+  EVENT_MAINTENANCE_STATE_CHANGED,
+  EVENT_TAGS_UPDATED
 } from "$lib/components/events/maintenance-popup-events";
 import type { MediaBoxTools } from "$lib/components/MediaBoxTools";
 
@@ -83,7 +83,7 @@ export class MaintenancePopup extends BaseComponent {
     this.container.classList.toggle('is-active', activeProfile !== null);
     this.#refreshTagsList();
 
-    this.#emitter.emit(eventActiveProfileChanged, activeProfile);
+    this.#emitter.emit(EVENT_ACTIVE_PROFILE_CHANGED, activeProfile);
   }
 
   #refreshTagsList() {
@@ -177,7 +177,7 @@ export class MaintenancePopup extends BaseComponent {
       }
 
       this.#isPlanningToSubmit = true;
-      this.#emitter.emit(eventMaintenanceStateChanged, 'waiting');
+      this.#emitter.emit(EVENT_MAINTENANCE_STATE_CHANGED, 'waiting');
     }
   }
 
@@ -204,7 +204,7 @@ export class MaintenancePopup extends BaseComponent {
     this.#isPlanningToSubmit = false;
     this.#isSubmitting = true;
 
-    this.#emitter.emit(eventMaintenanceStateChanged, 'processing');
+    this.#emitter.emit(EVENT_MAINTENANCE_STATE_CHANGED, 'processing');
 
     let maybeTagsAndAliasesAfterUpdate;
 
@@ -246,17 +246,17 @@ export class MaintenancePopup extends BaseComponent {
 
       MaintenancePopup.#notifyAboutPendingSubmission(false);
 
-      this.#emitter.emit(eventMaintenanceStateChanged, 'failed');
+      this.#emitter.emit(EVENT_MAINTENANCE_STATE_CHANGED, 'failed');
       this.#isSubmitting = false;
 
       return;
     }
 
     if (maybeTagsAndAliasesAfterUpdate) {
-      this.#emitter.emit(eventTagsUpdated, maybeTagsAndAliasesAfterUpdate);
+      this.#emitter.emit(EVENT_TAGS_UPDATED, maybeTagsAndAliasesAfterUpdate);
     }
 
-    this.#emitter.emit(eventMaintenanceStateChanged, 'complete');
+    this.#emitter.emit(EVENT_MAINTENANCE_STATE_CHANGED, 'complete');
 
     this.#tagsToAdd.clear();
     this.#tagsToRemove.clear();

--- a/src/lib/components/MaintenanceStatusIcon.ts
+++ b/src/lib/components/MaintenanceStatusIcon.ts
@@ -1,7 +1,7 @@
 import { BaseComponent } from "$lib/components/base/BaseComponent";
 import { getComponent } from "$lib/components/base/component-utils";
 import { on } from "$lib/components/events/comms";
-import { eventMaintenanceStateChanged } from "$lib/components/events/maintenance-popup-events";
+import { EVENT_MAINTENANCE_STATE_CHANGED } from "$lib/components/events/maintenance-popup-events";
 import type { MediaBoxTools } from "$lib/components/MediaBoxTools";
 
 export class MaintenanceStatusIcon extends BaseComponent {
@@ -22,7 +22,7 @@ export class MaintenanceStatusIcon extends BaseComponent {
       throw new Error('Status icon element initialized outside of the media box!');
     }
 
-    on(this.#mediaBoxTools, eventMaintenanceStateChanged, this.#onMaintenanceStateChanged.bind(this));
+    on(this.#mediaBoxTools, EVENT_MAINTENANCE_STATE_CHANGED, this.#onMaintenanceStateChanged.bind(this));
   }
 
   #onMaintenanceStateChanged(stateChangeEvent: CustomEvent<string>) {

--- a/src/lib/components/MediaBoxTools.ts
+++ b/src/lib/components/MediaBoxTools.ts
@@ -2,7 +2,7 @@ import { BaseComponent } from "$lib/components/base/BaseComponent";
 import { getComponent } from "$lib/components/base/component-utils";
 import { MaintenancePopup } from "$lib/components/MaintenancePopup";
 import { on } from "$lib/components/events/comms";
-import { eventActiveProfileChanged } from "$lib/components/events/maintenance-popup-events";
+import { EVENT_ACTIVE_PROFILE_CHANGED } from "$lib/components/events/maintenance-popup-events";
 import type { MediaBoxWrapper } from "$lib/components/MediaBoxWrapper";
 import type MaintenanceProfile from "$entities/MaintenanceProfile";
 
@@ -39,7 +39,7 @@ export class MediaBoxTools extends BaseComponent {
       }
     }
 
-    on(this, eventActiveProfileChanged, this.#onActiveProfileChanged.bind(this));
+    on(this, EVENT_ACTIVE_PROFILE_CHANGED, this.#onActiveProfileChanged.bind(this));
   }
 
   #onActiveProfileChanged(profileChangedEvent: CustomEvent<MaintenanceProfile | null>) {

--- a/src/lib/components/MediaBoxWrapper.ts
+++ b/src/lib/components/MediaBoxWrapper.ts
@@ -2,7 +2,7 @@ import { BaseComponent } from "$lib/components/base/BaseComponent";
 import { getComponent } from "$lib/components/base/component-utils";
 import { buildTagsAndAliasesMap } from "$lib/booru/tag-utils";
 import { on } from "$lib/components/events/comms";
-import { eventTagsUpdated } from "$lib/components/events/maintenance-popup-events";
+import { EVENT_TAGS_UPDATED } from "$lib/components/events/maintenance-popup-events";
 
 export class MediaBoxWrapper extends BaseComponent {
   #thumbnailContainer: HTMLElement | null = null;
@@ -13,7 +13,7 @@ export class MediaBoxWrapper extends BaseComponent {
     this.#thumbnailContainer = this.container.querySelector('.image-container');
     this.#imageLinkElement = this.#thumbnailContainer?.querySelector('a') || null;
 
-    on(this, eventTagsUpdated, this.#onTagsUpdatedRefreshTagsAndAliases.bind(this));
+    on(this, EVENT_TAGS_UPDATED, this.#onTagsUpdatedRefreshTagsAndAliases.bind(this));
   }
 
   #onTagsUpdatedRefreshTagsAndAliases(tagsUpdatedEvent: CustomEvent<Map<string, string> | null>) {

--- a/src/lib/components/TagDropdownWrapper.ts
+++ b/src/lib/components/TagDropdownWrapper.ts
@@ -4,8 +4,8 @@ import MaintenanceSettings from "$lib/extension/settings/MaintenanceSettings";
 import { getComponent } from "$lib/components/base/component-utils";
 import CustomCategoriesResolver from "$lib/extension/CustomCategoriesResolver";
 import { on } from "$lib/components/events/comms";
-import { eventFormEditorUpdated } from "$lib/components/events/tags-form-events";
-import { eventTagCustomGroupResolved } from "$lib/components/events/tag-dropdown-events";
+import { EVENT_FORM_EDITOR_UPDATED } from "$lib/components/events/tags-form-events";
+import { EVENT_TAG_GROUP_RESOLVED } from "$lib/components/events/tag-dropdown-events";
 import type TagGroup from "$entities/TagGroup";
 
 const categoriesResolver = new CustomCategoriesResolver();
@@ -54,7 +54,7 @@ export class TagDropdownWrapper extends BaseComponent {
       }
     });
 
-    on(this, eventTagCustomGroupResolved, this.#onTagGroupResolved.bind(this));
+    on(this, EVENT_TAG_GROUP_RESOLVED, this.#onTagGroupResolved.bind(this));
   }
 
   #onTagGroupResolved(resolvedGroupEvent: CustomEvent<TagGroup | null>) {
@@ -302,7 +302,7 @@ export function watchTagDropdownsInTagsEditor() {
   });
 
   // When form is submitted, its DOM is completely updated. We need to fetch those tags in this case.
-  on(document.body, eventFormEditorUpdated, event => {
+  on(document.body, EVENT_FORM_EDITOR_UPDATED, event => {
     for (const tagDropdownElement of event.detail.querySelectorAll<HTMLElement>('.tag.dropdown')) {
       wrapTagDropdown(tagDropdownElement);
     }

--- a/src/lib/components/TagsForm.ts
+++ b/src/lib/components/TagsForm.ts
@@ -1,15 +1,15 @@
 import { BaseComponent } from "$lib/components/base/BaseComponent";
 import { getComponent } from "$lib/components/base/component-utils";
 import { emit, on, type UnsubscribeFunction } from "$lib/components/events/comms";
-import { eventFetchComplete } from "$lib/components/events/booru-events";
-import { eventFormEditorUpdated } from "$lib/components/events/tags-form-events";
+import { EVENT_FETCH_COMPLETE } from "$lib/components/events/booru-events";
+import { EVENT_FORM_EDITOR_UPDATED } from "$lib/components/events/tags-form-events";
 
 export class TagsForm extends BaseComponent {
   protected init() {
     // Site sending the event when form is submitted vie Fetch API. We use this event to reload our logic here.
     const unsubscribe = on(
       this.container,
-      eventFetchComplete,
+      EVENT_FETCH_COMPLETE,
       () => this.#waitAndDetectUpdatedForm(unsubscribe),
     );
   }
@@ -36,7 +36,7 @@ export class TagsForm extends BaseComponent {
       const fullTagEditor = tagFormComponent.parentTagEditorElement;
 
       if (fullTagEditor) {
-        emit(document.body, eventFormEditorUpdated, fullTagEditor);
+        emit(document.body, EVENT_FORM_EDITOR_UPDATED, fullTagEditor);
       } else {
         console.info('Tag form is not in the tag editor. Event is not sent.');
       }

--- a/src/lib/components/TagsListBlock.ts
+++ b/src/lib/components/TagsListBlock.ts
@@ -2,9 +2,9 @@ import { BaseComponent } from "$lib/components/base/BaseComponent";
 import type TagGroup from "$entities/TagGroup";
 import type { TagDropdownWrapper } from "$lib/components/TagDropdownWrapper";
 import { on } from "$lib/components/events/comms";
-import { eventFormEditorUpdated } from "$lib/components/events/tags-form-events";
+import { EVENT_FORM_EDITOR_UPDATED } from "$lib/components/events/tags-form-events";
 import { getComponent } from "$lib/components/base/component-utils";
-import { eventTagCustomGroupResolved } from "$lib/components/events/tag-dropdown-events";
+import { EVENT_TAG_GROUP_RESOLVED } from "$lib/components/events/tag-dropdown-events";
 import TagSettings from "$lib/extension/settings/TagSettings";
 
 export class TagsListBlock extends BaseComponent {
@@ -32,7 +32,7 @@ export class TagsListBlock extends BaseComponent {
 
     on(
       this,
-      eventTagCustomGroupResolved,
+      EVENT_TAG_GROUP_RESOLVED,
       this.#onTagDropdownCustomGroupResolved.bind(this)
     );
   }
@@ -195,7 +195,7 @@ export function initializeAllTagsLists() {
 }
 
 export function watchForUpdatedTagLists() {
-  on(document, eventFormEditorUpdated, event => {
+  on(document, EVENT_FORM_EDITOR_UPDATED, event => {
     event.detail.closest('#image_tags_and_source')
   });
 }

--- a/src/lib/components/events/booru-events.ts
+++ b/src/lib/components/events/booru-events.ts
@@ -1,5 +1,5 @@
-export const eventFetchComplete = 'fetchcomplete';
+export const EVENT_FETCH_COMPLETE = 'fetchcomplete';
 
 export interface BooruEventsMap {
-  [eventFetchComplete]: null; // Site sends the response, but extension will not get it due to isolation.
+  [EVENT_FETCH_COMPLETE]: null; // Site sends the response, but extension will not get it due to isolation.
 }

--- a/src/lib/components/events/fullscreen-viewer-events.ts
+++ b/src/lib/components/events/fullscreen-viewer-events.ts
@@ -1,7 +1,7 @@
 import type { FullscreenViewerSize } from "$lib/extension/settings/MiscSettings";
 
-export const eventSizeLoaded = 'size-loaded';
+export const EVENT_SIZE_LOADED = 'size-loaded';
 
 export interface FullscreenViewerEventsMap {
-  [eventSizeLoaded]: FullscreenViewerSize;
+  [EVENT_SIZE_LOADED]: FullscreenViewerSize;
 }

--- a/src/lib/components/events/maintenance-popup-events.ts
+++ b/src/lib/components/events/maintenance-popup-events.ts
@@ -1,13 +1,13 @@
 import type MaintenanceProfile from "$entities/MaintenanceProfile";
 
-export const eventActiveProfileChanged = 'active-profile-changed';
-export const eventMaintenanceStateChanged = 'maintenance-state-change';
-export const eventTagsUpdated = 'tags-updated';
+export const EVENT_ACTIVE_PROFILE_CHANGED = 'active-profile-changed';
+export const EVENT_MAINTENANCE_STATE_CHANGED = 'maintenance-state-change';
+export const EVENT_TAGS_UPDATED = 'tags-updated';
 
 type MaintenanceState = 'processing' | 'failed' | 'complete' | 'waiting';
 
 export interface MaintenancePopupEventsMap {
-  [eventActiveProfileChanged]: MaintenanceProfile | null;
-  [eventMaintenanceStateChanged]: MaintenanceState;
-  [eventTagsUpdated]: Map<string, string> | null;
+  [EVENT_ACTIVE_PROFILE_CHANGED]: MaintenanceProfile | null;
+  [EVENT_MAINTENANCE_STATE_CHANGED]: MaintenanceState;
+  [EVENT_TAGS_UPDATED]: Map<string, string> | null;
 }

--- a/src/lib/components/events/tag-dropdown-events.ts
+++ b/src/lib/components/events/tag-dropdown-events.ts
@@ -1,7 +1,7 @@
 import type TagGroup from "$entities/TagGroup";
 
-export const eventTagCustomGroupResolved = 'tag-group-resolved';
+export const EVENT_TAG_GROUP_RESOLVED = 'tag-group-resolved';
 
 export interface TagDropdownEvents {
-    [eventTagCustomGroupResolved]: TagGroup | null;
+  [EVENT_TAG_GROUP_RESOLVED]: TagGroup | null;
 }

--- a/src/lib/components/events/tags-form-events.ts
+++ b/src/lib/components/events/tags-form-events.ts
@@ -1,5 +1,5 @@
-export const eventFormEditorUpdated = 'tags-form-updated';
+export const EVENT_FORM_EDITOR_UPDATED = 'tags-form-updated';
 
 export interface TagsFormEventsMap {
-  [eventFormEditorUpdated]: HTMLElement;
+  [EVENT_FORM_EDITOR_UPDATED]: HTMLElement;
 }

--- a/src/lib/extension/CustomCategoriesResolver.ts
+++ b/src/lib/extension/CustomCategoriesResolver.ts
@@ -2,7 +2,7 @@ import type { TagDropdownWrapper } from "$lib/components/TagDropdownWrapper";
 import TagGroup from "$entities/TagGroup";
 import { escapeRegExp } from "$lib/utils";
 import { emit } from "$lib/components/events/comms";
-import { eventTagCustomGroupResolved } from "$lib/components/events/tag-dropdown-events";
+import { EVENT_TAG_GROUP_RESOLVED } from "$lib/components/events/tag-dropdown-events";
 
 export default class CustomCategoriesResolver {
   #exactGroupMatches = new Map<string, TagGroup>();
@@ -58,7 +58,7 @@ export default class CustomCategoriesResolver {
 
     emit(
       tagDropdown,
-      eventTagCustomGroupResolved,
+      EVENT_TAG_GROUP_RESOLVED,
       this.#exactGroupMatches.get(tagName)!
     );
 
@@ -75,7 +75,7 @@ export default class CustomCategoriesResolver {
 
       emit(
         tagDropdown,
-        eventTagCustomGroupResolved,
+        EVENT_TAG_GROUP_RESOLVED,
         this.#regExpGroupMatches.get(targetRegularExpression)!
       );
 
@@ -119,7 +119,7 @@ export default class CustomCategoriesResolver {
   static #resetToOriginalCategory(tagDropdown: TagDropdownWrapper): void {
     emit(
       tagDropdown,
-      eventTagCustomGroupResolved,
+      EVENT_TAG_GROUP_RESOLVED,
       null,
     );
   }


### PR DESCRIPTION
Just a visual change to reduce confusion and more easily see what's a variable and what is a constant used on different components.