### PR TITLE
Reworked build step for content scripts & styles to use AMD as module system

### DIFF
--- a/.vite/lib/manifest.js
+++ b/.vite/lib/manifest.js
@@ -18,6 +18,38 @@ class ManifestProcessor {
   }
 
   /**
+   * Collect all the content scripts & stylesheets for single build action.
+   *
+   * @returns {Set<string>}
+   */
+  collectContentScripts() {
+    const contentScripts = this.#manifestObject.content_scripts;
+
+    if (!contentScripts) {
+      console.info('No content scripts to collect.');
+      return new Set();
+    }
+
+    const entryPoints = new Set();
+
+    for (let entry of contentScripts) {
+      if (entry.js) {
+        for (let jsPath of entry.js) {
+          entryPoints.add(jsPath);
+        }
+      }
+
+      if (entry.css) {
+        for (let cssPath of entry.css) {
+          entryPoints.add(cssPath);
+        }
+      }
+    }
+
+    return entryPoints;
+  }
+
+  /**
    * Map over every content script defined in the manifest. If no content scripts defined, no calls will be made to the
    * callback.
    *

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,14 @@
     "content_scripts": [
         {
             "matches": [
+                "*://*.furbooru.org/*"
+            ],
+            "js": [
+                "src/content/deps/amd.ts"
+            ]
+        },
+        {
+            "matches": [
                 "*://*.furbooru.org/",
                 "*://*.furbooru.org/images?*",
                 "*://*.furbooru.org/search?*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.4.4",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.7.2",
+                "amd-lite": "^1.0.1",
                 "lz-string": "^1.5.0"
             },
             "devDependencies": {
@@ -1387,6 +1388,12 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/amd-lite": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amd-lite/-/amd-lite-1.0.1.tgz",
+            "integrity": "sha512-2EqBXjF5YjgCHeb4hfhUx3iIiN/vmuXjXdT1QVDXylwH5c2oqEvGPDmyVo9yGRGEQlGRdwa9gJ68/m32yUnriw==",
+            "license": "MIT"
         },
         "node_modules/ansi-regex": {
             "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "type": "module",
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
+        "amd-lite": "^1.0.1",
         "lz-string": "^1.5.0"
     }
 }

--- a/src/content/deps/amd.ts
+++ b/src/content/deps/amd.ts
@@ -1,0 +1,22 @@
+import { amdLite } from "amd-lite";
+
+const originalDefine = amdLite.define;
+
+amdLite.define = (name, dependencies, originalCallback) => {
+  return originalDefine(name, dependencies, function () {
+    const callbackResult = originalCallback(...arguments);
+
+    // Workaround for the entry script not returning anything causing AMD-Lite to send warning about modules not
+    // being loaded/not existing.
+    return typeof callbackResult !== 'undefined' ? callbackResult : {};
+  })
+}
+
+amdLite.init({
+  publicScope: window
+});
+
+// We don't have anything asynchronous, so it's safe to execute everything on the next frame.
+requestAnimationFrame(() => {
+  amdLite.resolveDependencies(Object.keys(amdLite.waitingModules))
+});

--- a/src/types/amd-lite.d.ts
+++ b/src/types/amd-lite.d.ts
@@ -1,0 +1,23 @@
+// Types for the small untyped AMD loader. These types do not cover all the functions available in the package, only
+// parts required for content scripts in extension to work.
+declare module 'amd-lite' {
+  interface AMDLiteInitOptions {
+    publicScope: any;
+    verbosity: number;
+  }
+
+  interface AMDLite {
+    waitingModules: Record<string, any>;
+    readyModules: Record<string, any>;
+
+    init(options: Partial<AMDLiteInitOptions>): void;
+
+    define(name: string, dependencies: string[], callback: function): void;
+
+    resolveDependency(dependencyPath: string);
+
+    resolveDependencies(dependencyNames: string[], from?: string);
+  }
+
+  export const amdLite: AMDLite;
+}


### PR DESCRIPTION
Previously, because of how scripts were build with ES modules in mind, I couldn't build all the content scripts in a single step. To work around this I did separate build for every single content script, so Vite & Rollup would give me separate chunk for them.

While it was working fine, it caused unnecessary duplication of dependencies. Base classes were redefined several times for each content script.

This issue is now resolved with this updated build step. All modules are build in AMD format. Dependencies are then collected and automatically injected into manifest.json. And then AMD loader is forced to load every single registered dependency.

I selected `amd-lite` as the loader of choice, since it's tiny and I need only a fraction of features usually provided by the proper AMD implementations.