### PR TITLE
Content Scripts: Enabled minification of exported properties

### DIFF
--- a/.vite/lib/content-scripts.js
+++ b/.vite/lib/content-scripts.js
@@ -175,7 +175,9 @@ export async function buildScriptsAndStyles(buildOptions) {
           amd: {
             // amd-lite requires names even for the entry-point scripts, so we should make sure to add those.
             autoId: true,
-          }
+          },
+          // All these modules are not intended to be used outside of extension anyway
+          minifyInternalExports: true,
         }
       },
       emptyOutDir: false,


### PR DESCRIPTION
I've noticed that exported object and variables were not minified in content scripts after merging #119. Now they're properly minified.

Since all of the APIs are internal, there is no point in preserving full names for exported objects & properties.