### PR TITLE
Fixed header in popup having wrong z-index

### DIFF
--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -13,6 +13,7 @@
     top: 0;
     left: 0;
     right: 0;
+    z-index: 10;
 
     a {
       color: colors.$text;


### PR DESCRIPTION
Just a quick fix for the header appearing behind some elements instead of covering them. This especially visible once scrolling starts.