### PR TITLE
Firefox: Fixed an error message appearing when single chunk is trying to execute multiple times

### DIFF
--- a/src/content/deps/amd.ts
+++ b/src/content/deps/amd.ts
@@ -2,7 +2,21 @@ import { amdLite } from "amd-lite";
 
 const originalDefine = amdLite.define;
 
+/**
+ * Set of already defined modules. Used for deduplication.
+ */
+const definedModules = new Set<string>();
+
 amdLite.define = (name, dependencies, originalCallback) => {
+  // Chrome doesn't run the same content script multiple times, while Firefox does. Since each content script and their
+  // chunks are intended to be run only once, we should just ignore any attempts of running the same module more than
+  // once. Names of the modules are assumed to be unique.
+  if (definedModules.has(name)) {
+    return;
+  }
+
+  definedModules.add(name);
+
   return originalDefine(name, dependencies, function () {
     const callbackResult = originalCallback(...arguments);
 


### PR DESCRIPTION
Seems like Chromium avoids running the same script multiple times, even if this script is defined in multiple content script entries. But Firefox isn't doing that, causing AMD loader to throw an error about attempting to run the same module second time. This PR makes sure that module with the same name will be ignored if called more than once.