### PR TITLE
Profile View: Fixed tags list not being properly reactive in the extension popup

### DIFF
--- a/src/components/features/ProfileView.svelte
+++ b/src/components/features/ProfileView.svelte
@@ -7,7 +7,7 @@
 
   let { profile }: ProfileViewProps = $props();
 
-  const sortedTagsList = profile.settings.tags.sort((a, b) => a.localeCompare(b));
+  const sortedTagsList = $derived(profile.settings.tags.sort((a, b) => a.localeCompare(b)));
 </script>
 
 <div class="block">


### PR DESCRIPTION
This likely wasn't being seen in practice. And tag groups view already using $derived and therefore properly reacts to changes to the property.