### PR TITLE
Fixed custom categories not refreshing on tags once last group is deleted

### DIFF
--- a/src/lib/extension/CustomCategoriesResolver.ts
+++ b/src/lib/extension/CustomCategoriesResolver.ts
@@ -90,6 +90,7 @@ export default class CustomCategoriesResolver {
     this.#regExpGroupMatches.clear();
 
     if (!tagGroups.length) {
+      this.#queueUpdatingTags();
       return;
     }
 


### PR DESCRIPTION
Custom categories were not refreshed when last group was deleted from the extension — I just forgot to call the refresh in this case.