### PR TITLE
Firefox: Specify no data collection required by the extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,12 @@
     "version": "0.6.0",
     "browser_specific_settings": {
         "gecko": {
-            "id": "furbooru-tagging-assistant@thecore.city"
+            "id": "furbooru-tagging-assistant@thecore.city",
+            "data_collection_permissions": {
+                "required": [
+                    "none"
+                ]
+            }
         }
     },
     "icons": {


### PR DESCRIPTION
This extension doesn't track anything about the user or their activities inside the sites (Furbooru/Derpibooru/Tantabus) or inside the extension.

This new property is required for new addons and will be required for existing addons later.