### PR TITLE
Release: 0.6.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Furbooru Tagging Assistant",
     "description": "Small experimental extension for slightly quicker tagging experience. Furbooru Edition.",
-    "version": "0.6.0",
+    "version": "0.6.0.1",
     "browser_specific_settings": {
         "gecko": {
             "id": "furbooru-tagging-assistant@thecore.city",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "furbooru-tagging-assistant",
-    "version": "0.6.0",
+    "version": "0.6.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "furbooru-tagging-assistant",
-            "version": "0.6.0",
+            "version": "0.6.0.1",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^7.2.0",
                 "@sveltejs/adapter-static": "^3.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "furbooru-tagging-assistant",
-    "version": "0.6.0",
+    "version": "0.6.0.1",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Just quick fix for the issue which doesn't allow Tantabus version of extension to be uploaded on Mozilla's addon store.