### PR TITLE
Presets: Added option to make presets conditional

### DIFF
--- a/src/components/features/PresetView.svelte
+++ b/src/components/features/PresetView.svelte
@@ -10,6 +10,7 @@
   let { preset }: PresetViewProps = $props();
 
   const sortedTagsList = $derived(preset.settings.tags.toSorted((a, b) => a.localeCompare(b)));
+  const requiredTagsList = $derived(preset.settings.requiredTags.toSorted((a, b) => a.localeCompare(b)));
 </script>
 
 <DetailsBlock title="Preset Name">
@@ -22,5 +23,13 @@
   <DetailsBlock title="Exclusivity">
     Only one tag in this preset should be active at a time. If you will click on other non-active tag, other tags will
     be automatically removed from the editor.
+  </DetailsBlock>
+{/if}
+{#if preset.settings.conditional}
+  <DetailsBlock title="Conditional">
+    This preset will only appear when one of the tags below are present on image.
+  </DetailsBlock>
+  <DetailsBlock title="Conditional Tags">
+    <TagsList tags={requiredTagsList}></TagsList>
   </DetailsBlock>
 {/if}

--- a/src/content/components/extension/presets/PresetTableRow.ts
+++ b/src/content/components/extension/presets/PresetTableRow.ts
@@ -5,12 +5,13 @@ import { EVENT_PRESET_TAG_CHANGE_APPLIED } from "$content/components/events/pres
 import { createFontAwesomeIcon } from "$lib/dom-utils";
 
 export default class PresetTableRow extends BaseComponent {
-  #preset: TagEditorPreset;
+  readonly #preset: TagEditorPreset;
+  readonly #applyAllButton = document.createElement('button');
+  readonly #removeAllButton = document.createElement('button');
+  readonly #exclusiveWarning = document.createElement('div');
+  readonly #alternateColorDummy = document.createElement('span');
+
   #tagsList: HTMLElement[] = [];
-  #applyAllButton = document.createElement('button');
-  #removeAllButton = document.createElement('button');
-  #exclusiveWarning = document.createElement('div');
-  #alternateColorDummy = document.createElement('span');
 
   constructor(container: HTMLElement, preset: TagEditorPreset) {
     super(container);

--- a/src/content/components/extension/presets/PresetTableRow.ts
+++ b/src/content/components/extension/presets/PresetTableRow.ts
@@ -9,6 +9,7 @@ export default class PresetTableRow extends BaseComponent {
   #tagsList: HTMLElement[] = [];
   #applyAllButton = document.createElement('button');
   #removeAllButton = document.createElement('button');
+  #alternateColorDummy = document.createElement('span');
 
   constructor(container: HTMLElement, preset: TagEditorPreset) {
     super(container);
@@ -64,6 +65,8 @@ export default class PresetTableRow extends BaseComponent {
       tagsCell,
       actionsCell,
     );
+
+    this.#alternateColorDummy.style.display = 'none';
   }
 
   protected init() {
@@ -108,6 +111,26 @@ export default class PresetTableRow extends BaseComponent {
     });
   }
 
+  #maybeRefreshVisibilityFromTags(sourceTags: Set<string>) {
+    if (!this.#preset.settings.conditional || this.#isMatchesConditional(sourceTags)) {
+      this.container.style.display = '';
+      this.#alternateColorDummy.remove();
+      return;
+    }
+
+    this.container.style.display = 'none';
+    this.container.after(this.#alternateColorDummy);
+  }
+
+  #isMatchesConditional(sourceTags: Set<string>): boolean {
+    const listOfRequiredTags = this.#preset.settings.requiredTags;
+
+    return Boolean(
+      listOfRequiredTags.length
+      && listOfRequiredTags.some(tagName => sourceTags.has(tagName))
+    );
+  }
+
   updateTags(tags: Set<string>) {
     for (const tagElement of this.#tagsList) {
       tagElement.classList.toggle(
@@ -115,6 +138,8 @@ export default class PresetTableRow extends BaseComponent {
         !tags.has(tagElement.dataset.tagName || ''),
       );
     }
+
+    this.#maybeRefreshVisibilityFromTags(tags);
   }
 
   remove() {

--- a/src/lib/extension/entities/TagEditorPreset.ts
+++ b/src/lib/extension/entities/TagEditorPreset.ts
@@ -13,7 +13,7 @@ export default class TagEditorPreset extends StorageEntity<TagEditorPresetSettin
     super(id, {
       name: settings.name || '',
       tags: settings.tags || [],
-      exclusive: settings.exclusive ?? false
+      exclusive: settings.exclusive ?? false,
       conditional: settings.conditional || false,
       requiredTags: settings.requiredTags || [],
     });

--- a/src/lib/extension/entities/TagEditorPreset.ts
+++ b/src/lib/extension/entities/TagEditorPreset.ts
@@ -3,6 +3,8 @@ import StorageEntity from "$lib/extension/base/StorageEntity";
 interface TagEditorPresetSettings {
   name: string;
   tags: string[];
+  conditional: boolean;
+  requiredTags: string[];
 }
 
 export default class TagEditorPreset extends StorageEntity<TagEditorPresetSettings> {
@@ -10,6 +12,8 @@ export default class TagEditorPreset extends StorageEntity<TagEditorPresetSettin
     super(id, {
       name: settings.name || '',
       tags: settings.tags || [],
+      conditional: settings.conditional || false,
+      requiredTags: settings.requiredTags || [],
     });
   }
 

--- a/src/lib/extension/transporting/exporters.ts
+++ b/src/lib/extension/transporting/exporters.ts
@@ -42,6 +42,8 @@ const entitiesExporters: ExportersMap = {
       id: entity.id,
       name: entity.settings.name,
       tags: entity.settings.tags,
+      conditional: entity.settings.conditional,
+      requiredTags: entity.settings.requiredTags,
     }
   }
 };

--- a/src/lib/extension/transporting/validators.ts
+++ b/src/lib/extension/transporting/validators.ts
@@ -29,7 +29,7 @@ function validateRequiredString(value: unknown): boolean {
  * @param value Value to be checked.
  */
 function validateOptionalArray(value: unknown): boolean {
-  return typeof value === 'undefined' || value === null || Array.isArray(value);
+  return value === undefined || value === null || Array.isArray(value);
 }
 
 /**
@@ -37,7 +37,7 @@ function validateOptionalArray(value: unknown): boolean {
  * @param value Value to be checked.
  */
 function validateOptionalBoolean(value: unknown): boolean {
-  return typeof value === 'undefined' || typeof value === 'boolean';
+  return value === undefined || typeof value === 'boolean';
 }
 
 /**

--- a/src/lib/extension/transporting/validators.ts
+++ b/src/lib/extension/transporting/validators.ts
@@ -33,6 +33,14 @@ function validateOptionalArray(value: unknown): boolean {
 }
 
 /**
+ * Check if the following value is not set or is a valid boolean.
+ * @param value Value to be checked.
+ */
+function validateOptionalBoolean(value: unknown): boolean {
+  return typeof value === 'undefined' || typeof value === 'boolean';
+}
+
+/**
  * Map of validators for each entity. Function should throw the error if validation failed.
  */
 const entitiesValidators: EntitiesValidationMap = {
@@ -73,7 +81,8 @@ const entitiesValidators: EntitiesValidationMap = {
       !validateRequiredString(importedObject?.id)
       || !validateRequiredString(importedObject?.name)
       || !validateOptionalArray(importedObject?.tags)
-      || typeof importedObject.conditional !== 'boolean'
+      || !validateOptionalBoolean(importedObject?.exclusive)
+      || !validateOptionalBoolean(importedObject?.conditional)
       || !validateOptionalArray(importedObject?.requiredTags)
     ) {
       throw new Error('Invalid preset format detected!');

--- a/src/lib/extension/transporting/validators.ts
+++ b/src/lib/extension/transporting/validators.ts
@@ -73,6 +73,8 @@ const entitiesValidators: EntitiesValidationMap = {
       !validateRequiredString(importedObject?.id)
       || !validateRequiredString(importedObject?.name)
       || !validateOptionalArray(importedObject?.tags)
+      || typeof importedObject.conditional !== 'boolean'
+      || !validateOptionalArray(importedObject?.requiredTags)
     ) {
       throw new Error('Invalid preset format detected!');
     }

--- a/src/routes/features/presets/[id]/edit/+page.svelte
+++ b/src/routes/features/presets/[id]/edit/+page.svelte
@@ -84,7 +84,7 @@
   </FormControl>
   <FormControl>
     <CheckboxField bind:checked={isConditional}>
-      Show this preset only when specified tags are provided.
+      Show this preset only when any of specified tags are provided.
     </CheckboxField>
   </FormControl>
   {#if isConditional}

--- a/src/routes/features/presets/[id]/edit/+page.svelte
+++ b/src/routes/features/presets/[id]/edit/+page.svelte
@@ -10,6 +10,7 @@
   import FormControl from "$components/ui/forms/FormControl.svelte";
   import TextField from "$components/ui/forms/TextField.svelte";
   import TagsEditor from "$components/tags/TagsEditor.svelte";
+  import CheckboxField from "$components/ui/forms/CheckboxField.svelte";
 
   let presetId = $derived(page.params.id);
 
@@ -23,6 +24,8 @@
 
   let presetName = $state('');
   let tagsList = $state<string[]>([]);
+  let isConditional = $state<boolean>(false);
+  let requiredTags = $state<string[]>([]);
 
   $effect(() => {
     if (presetId === 'new') {
@@ -39,6 +42,8 @@
 
     presetName = targetPreset.settings.name;
     tagsList = [...targetPreset.settings.tags].sort((a, b) => a.localeCompare(b));
+    isConditional = targetPreset.settings.conditional;
+    requiredTags = [...targetPreset.settings.requiredTags].sort((a, b) => a.localeCompare(b));
   });
 
   async function savePreset() {
@@ -49,6 +54,8 @@
 
     targetPreset.settings.name = presetName;
     targetPreset.settings.tags = [...tagsList];
+    targetPreset.settings.conditional = isConditional;
+    targetPreset.settings.requiredTags = [...requiredTags];
 
     await targetPreset.save();
     await goto(`/features/presets/${targetPreset.id}`);
@@ -67,6 +74,16 @@
   <FormControl label="Tags">
     <TagsEditor bind:tags={tagsList}></TagsEditor>
   </FormControl>
+  <FormControl>
+    <CheckboxField bind:checked={isConditional}>
+      Show this preset only when specified tags are provided.
+    </CheckboxField>
+  </FormControl>
+  {#if isConditional}
+    <FormControl label="Required Tags">
+      <TagsEditor bind:tags={requiredTags}></TagsEditor>
+    </FormControl>
+  {/if}
 </FormContainer>
 <Menu>
   <hr>

--- a/src/styles/content/tag-presets.scss
+++ b/src/styles/content/tag-presets.scss
@@ -3,6 +3,7 @@
 .block.tag-presets {
   .tag {
     cursor: pointer;
+    user-select: none;
 
     &.is-missing {
       opacity: 0.5;


### PR DESCRIPTION
With this option, presets can be configured to show up only when certain tags are present in the image. This way user can have multi-staged group of presets going from general presets to specific ones.