### PR TITLE
Updated link to repository inside the extension

### DIFF
--- a/src/components/layout/Footer.svelte
+++ b/src/components/layout/Footer.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <footer>
-  <a href="https://github.com/koloml/furbooru-tagging-assistant/releases/tag/{version}" target="_blank">
+  <a href="https://github.com/koloml/philomena-tagging-assistant/releases/tag/{version}" target="_blank">
     v{version}
   </a>
   <span>, made with ♥ by KoloMl.</span>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -34,7 +34,7 @@
   <MenuItem href={currentSiteUrl} icon="globe" target="_blank">
     Visit {__CURRENT_SITE_NAME__}
   </MenuItem>
-  <MenuItem href="https://github.com/koloml/furbooru-tagging-assistant" icon="info-circle" target="_blank">
+  <MenuItem href="https://github.com/koloml/philomena-tagging-assistant" icon="info-circle" target="_blank">
     GitHub Repo
   </MenuItem>
 </Menu>


### PR DESCRIPTION
Repository was renamed from Furbooru Tagging Assistant to Philomena Tagging Assistant, since it's targeted at the booru engine itself and not just on a single website. While redirects do work, it's better to have this link up-to-date.